### PR TITLE
Fix issue when partitioning ways due to max length

### DIFF
--- a/src/OSMDocument.cpp
+++ b/src/OSMDocument.cpp
@@ -120,6 +120,7 @@ void OSMDocument::SplitWays() {
                 // Close the splitted way if we'd be exceeding max length by adding the next node,
                 // but only if this is not the 2nd node in the way
                 if (prevNode != node && splitted_way->length + length > MAX_LENGTH) {
+                    it_node--;
                     splitted_way->geom+= ")";
                     break;
                 }


### PR DESCRIPTION
The last node was not being added to the new splitted way.
